### PR TITLE
Fix incorrect calculation of roll in splines

### DIFF
--- a/Assets/SplineMesh/Scripts/Bezier/SplineSample.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/SplineSample.cs
@@ -25,7 +25,7 @@ namespace SplineMesh {
         public Quaternion Rotation {
             get {
                 if (rotation.Equals(Quaternion.identity)) {
-                    var upVector = Vector3.Cross(tangent, Vector3.Cross(Quaternion.AngleAxis(roll, Vector3.forward) * up, tangent).normalized);
+                    var upVector = Quaternion.AngleAxis(roll, tangent) * Vector3.up;
                     rotation =  Quaternion.LookRotation(tangent, upVector);
                 }
                 return rotation;

--- a/Assets/SplineMesh/Scripts/Example/ExtrusionSegment.cs
+++ b/Assets/SplineMesh/Scripts/Example/ExtrusionSegment.cs
@@ -61,7 +61,6 @@ namespace SplineMesh {
                     position = sample.location,
                     rotation = sample.Rotation,
                     scale = sample.scale,
-                    roll = sample.roll
                 });
             }
             sample = curve.GetSample(1);
@@ -69,7 +68,6 @@ namespace SplineMesh {
                 position = sample.location,
                 rotation = sample.Rotation,
                 scale = sample.scale,
-                roll = sample.roll
             });
             return path;
         }
@@ -93,9 +91,6 @@ namespace SplineMesh {
                     var position = v.point;
                     // apply scale
                     position = Vector3.Scale(position, new Vector3(op.scale.x, op.scale.y, 0));
-
-                    // apply roll
-                    position = Quaternion.AngleAxis(op.roll, Vector3.forward) * position;
 
                     vertices[index] = op.LocalToWorld(position);
                     normals[index] = op.LocalToWorldDirection(v.normal);
@@ -145,7 +140,6 @@ namespace SplineMesh {
             public Vector3 position;
             public Quaternion rotation;
             public Vector2 scale;
-            public float roll;
 
             public Vector3 LocalToWorld(Vector3 point) {
                 return position + rotation * point;


### PR DESCRIPTION
Roll worked correctly only if the spline was oriented along the X-axis. This fix makes it work with any direction.

Furthermore, undesirable roll was applied to ExtrusionSegments - roll already comes baked into a SplineSample's rotation.