### PR TITLE
Up vector should be added before world space conversion.

### DIFF
--- a/Assets/SplineMesh/Scripts/Editor/SplineEditor.cs
+++ b/Assets/SplineMesh/Scripts/Editor/SplineEditor.cs
@@ -124,7 +124,7 @@ namespace SplineMesh {
                     selection.Direction = 2 * selection.Position - spline.transform.InverseTransformPoint(result);
                     break;
                 case SelectionType.Up:
-                    result = Handles.PositionHandle(spline.transform.TransformPoint(selection.Position) + selection.Up, Quaternion.LookRotation(selection.Direction - selection.Position));
+                    result = Handles.PositionHandle(spline.transform.TransformPoint(selection.Position + selection.Up), Quaternion.LookRotation(selection.Direction - selection.Position));
                     selection.Up = (spline.transform.InverseTransformPoint(result) - selection.Position).normalized;
                     break;
             }


### PR DESCRIPTION
To fix problems when world space has a different rotation than the spline.

Tested with Unity 2019.2.