### PR TITLE
Fix samples initialisation

### DIFF
--- a/Assets/SplineMesh/Scripts/Bezier/CubicBezierCurve.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/CubicBezierCurve.cs
@@ -18,9 +18,16 @@ namespace SplineMesh {
         private const int STEP_COUNT = 30;
         private const float T_STEP = 1.0f / STEP_COUNT;
 
-        private readonly List<CurveSample> samples = new List<CurveSample>(STEP_COUNT);
+        private List<CurveSample> samples = new List<CurveSample>(STEP_COUNT);
 
         public SplineNode n1, n2;
+        
+        // Initialise on deserialisation.
+        [OnDeserialized]
+        private void ResetSampleList()
+        {
+            samples = new List<CurveSample>(STEP_COUNT);
+        }
 
         /// <summary>
         /// Length of the curve in world unit.

--- a/Assets/SplineMesh/Scripts/Bezier/CubicBezierCurve.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/CubicBezierCurve.cs
@@ -22,10 +22,10 @@ namespace SplineMesh {
 
         public SplineNode n1, n2;
         
-        // Initialise on deserialisation.
         [OnDeserialized]
         private void ResetSampleList()
         {
+            // samples is null by default after deserialisation.
             samples = new List<CurveSample>(STEP_COUNT);
         }
 


### PR DESCRIPTION
samples is not initialised correctly when CubicBezierCurve is deserialised resulting in null reference exceptions.