### PR TITLE
fix: uv u coordinate follows the vertices

### DIFF
--- a/Assets/SplineMesh/Scripts/MeshProcessing/ExtrusionSegment.cs
+++ b/Assets/SplineMesh/Scripts/MeshProcessing/ExtrusionSegment.cs
@@ -170,11 +170,17 @@ namespace SplineMesh {
             var bentVertices = new List<MeshVertex>(vertsInShape * 2 * segmentCount * 3);
 
             foreach (var sample in path) {
-                foreach (Vertex v in shapeVertices) {
-                    bentVertices.Add(sample.GetBent(new MeshVertex(
-                        new Vector3(0, v.point.y, -v.point.x),
-                        new Vector3(0, v.normal.y, -v.normal.x),
-                        new Vector2(v.uCoord, textureScale * (sample.distanceInCurve + textureOffset)))));
+                for (int i = 0; i < shapeVertices.Count; i++)
+                {
+                    Vertex vertex = shapeVertices[i];
+                    Vector3 vert = new Vector3(0, vertex.point.y, -vertex.point.x);
+                    Vector3 normal = new Vector3(0, vertex.normal.y, -vertex.normal.x);
+
+                    float u = (1f / shapeVertices.Count) * i;
+                    float v = textureScale * (sample.distanceInCurve + textureOffset);
+                    Vector3 uv = new Vector2(u, v);
+
+                    bentVertices.Add(sample.GetBent(new MeshVertex(vert, normal, uv)));
                 }
             }
             var index = 0;


### PR DESCRIPTION
If you create a new vertex the U coordinate is inherited from the selected vertex. The U is defined in the construction of the spline. Here the U coordinate is computed from the distance across the vertices, similar to how the V coordinate is computed from the spline distance.

![SUV](https://user-images.githubusercontent.com/7163145/81600428-7b9bca00-93c1-11ea-9fb2-2576b38efc7b.png)