### PR TITLE
feat: allow uvs to flip and scale texture on u and v

### DIFF
--- a/Assets/SplineMesh/Scripts/Editor/SplineExtrusionEditor.cs
+++ b/Assets/SplineMesh/Scripts/Editor/SplineExtrusionEditor.cs
@@ -9,6 +9,7 @@ namespace SplineMesh {
         private Color CURVE_COLOR = new Color(0.8f, 0.8f, 0.8f);
         private bool mustCreateNewNode = false;
         private SerializedProperty textureScale;
+        private SerializedProperty flipUvs;
         private SerializedProperty sampleSpacing;
         private SerializedProperty material;
         private SerializedProperty vertices;
@@ -19,6 +20,7 @@ namespace SplineMesh {
         private void OnEnable() {
             se = (SplineExtrusion)target;
             textureScale = serializedObject.FindProperty("textureScale");
+            flipUvs = serializedObject.FindProperty("flipUvs");
             sampleSpacing = serializedObject.FindProperty("sampleSpacing");
             material = serializedObject.FindProperty("material");
             vertices = serializedObject.FindProperty("shapeVertices");
@@ -145,6 +147,7 @@ namespace SplineMesh {
 
             // Properties
             EditorGUILayout.PropertyField(textureScale, true);
+            EditorGUILayout.PropertyField(flipUvs, true);
             EditorGUILayout.PropertyField(sampleSpacing, true);
             EditorGUILayout.PropertyField(material, true);
 

--- a/Assets/SplineMesh/Scripts/MeshProcessing/ExtrusionSegment.cs
+++ b/Assets/SplineMesh/Scripts/MeshProcessing/ExtrusionSegment.cs
@@ -33,16 +33,31 @@ namespace SplineMesh {
             }
         }
 
-        private float textureScale = 1;
+        private Vector2 textureScale = new Vector2(1, 1);
         /// <summary>
         /// 
         /// </summary>
-        public float TextureScale {
+        public Vector2 TextureScale {
             get { return textureScale; }
             set {
                 if (value == textureScale) return;
                 SetDirty();
                 textureScale = value;
+            }
+        }
+
+        private bool flipUvs = false;
+        /// <summary>
+        /// Flip the UVs
+        /// </summary>
+        public bool FlipUvs
+        {
+            get { return flipUvs; }
+            set
+            {
+                if (value == flipUvs) return;
+                SetDirty();
+                flipUvs = value;
             }
         }
 
@@ -170,11 +185,21 @@ namespace SplineMesh {
             var bentVertices = new List<MeshVertex>(vertsInShape * 2 * segmentCount * 3);
 
             foreach (var sample in path) {
-                foreach (Vertex v in shapeVertices) {
-                    bentVertices.Add(sample.GetBent(new MeshVertex(
-                        new Vector3(0, v.point.y, -v.point.x),
-                        new Vector3(0, v.normal.y, -v.normal.x),
-                        new Vector2(v.uCoord, textureScale * (sample.distanceInCurve + textureOffset)))));
+                for (int i = 0; i < shapeVertices.Count; i++)
+                {
+                    Vertex vertex = shapeVertices[i];
+                    Vector3 vert = new Vector3(0, vertex.point.y, -vertex.point.x);
+                    Vector3 normal = new Vector3(0, vertex.normal.y, -vertex.normal.x);
+
+                    float u = (1f / shapeVertices.Count) * i;
+                    float v = sample.distanceInCurve + textureOffset;
+
+                    Vector3 uv = new Vector2(
+                        (flipUvs ? v : u) * textureScale.y,
+                        (flipUvs ? u : v) * textureScale.x
+                    );
+
+                    bentVertices.Add(sample.GetBent(new MeshVertex(vert, normal, uv)));
                 }
             }
             var index = 0;

--- a/Assets/SplineMesh/Scripts/MeshProcessing/SplineExtrusion.cs
+++ b/Assets/SplineMesh/Scripts/MeshProcessing/SplineExtrusion.cs
@@ -30,7 +30,8 @@ namespace SplineMesh {
 
         public List<ExtrusionSegment.Vertex> shapeVertices = new List<ExtrusionSegment.Vertex>();
         public Material material;
-        public float textureScale = 1;
+        public Vector2 textureScale = new Vector2(1, 1);
+        public bool flipUvs = false;
         public float sampleSpacing = 0.1f;
 
         /// <summary>
@@ -81,6 +82,7 @@ namespace SplineMesh {
                 ExtrusionSegment mb = go.GetComponent<ExtrusionSegment>();
                 mb.ShapeVertices = shapeVertices;
                 mb.TextureScale = textureScale;
+                mb.FlipUvs = flipUvs;
                 mb.TextureOffset = textureOffset;
                 mb.SampleSpacing = sampleSpacing;
                 mb.SetInterval(curve);


### PR DESCRIPTION
Instead of just having a single axis for the texture and scaling we can now have both.

![smr](https://user-images.githubusercontent.com/7163145/81604669-28794580-93c8-11ea-83f5-596ccf71ad65.png)

