### PR TITLE
Misc. spline extrusion properties and expose spline index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ExportedObj/
 *.pdb
 *.opendb
 *.VC.db
+*.vsconfig
 
 # Unity3D generated meta files
 *.pidb.meta

--- a/Assets/SplineMesh/Scripts/Bezier/CurveSample.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/CurveSample.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -18,6 +18,7 @@ namespace SplineMesh {
         public readonly float distanceInCurve;
         public readonly float timeInCurve;
         public readonly CubicBezierCurve curve;
+        public int index;
 
         private Quaternion rotation;
 
@@ -43,6 +44,7 @@ namespace SplineMesh {
             this.distanceInCurve = distanceInCurve;
             this.timeInCurve = timeInCurve;
             this.curve = curve;
+            index = -1;
             rotation = Quaternion.identity;
         }
 

--- a/Assets/SplineMesh/Scripts/Bezier/Spline.cs
+++ b/Assets/SplineMesh/Scripts/Bezier/Spline.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -286,10 +286,12 @@ namespace SplineMesh {
         public CurveSample GetProjectionSample(Vector3 pointToProject) {
             CurveSample closest = default(CurveSample);
             float minSqrDistance = float.MaxValue;
-            foreach (var curve in curves) {
+            for (int i = 0; i < curves.Count; i++) {
+                var curve = curves[i];
                 var projection = curve.GetProjectionSample(pointToProject);
                 if (curve == curves[0]) {
                     closest = projection;
+                    closest.index = i;
                     minSqrDistance = (projection.location - pointToProject).sqrMagnitude;
                     continue;
                 }
@@ -297,6 +299,7 @@ namespace SplineMesh {
                 if (sqrDist < minSqrDistance) {
                     minSqrDistance = sqrDist;
                     closest = projection;
+                    closest.index = i;
                 }
             }
             return closest;

--- a/Assets/SplineMesh/Scripts/Editor/SplineExtrusionEditor.cs
+++ b/Assets/SplineMesh/Scripts/Editor/SplineExtrusionEditor.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Collections;
 using UnityEditor;
 
@@ -12,16 +12,22 @@ namespace SplineMesh {
         private SerializedProperty sampleSpacing;
         private SerializedProperty material;
         private SerializedProperty vertices;
+        private SerializedProperty layer;
+        private SerializedProperty visible;
+        private SerializedProperty collisionEnabled;
 
         private SplineExtrusion se;
         private ExtrusionSegment.Vertex selection = null;
 
-        private void OnEnable() {
+        protected void OnEnable() {
             se = (SplineExtrusion)target;
             textureScale = serializedObject.FindProperty("textureScale");
             sampleSpacing = serializedObject.FindProperty("sampleSpacing");
             material = serializedObject.FindProperty("material");
             vertices = serializedObject.FindProperty("shapeVertices");
+            layer = serializedObject.FindProperty("layer");
+            visible = serializedObject.FindProperty("visible");
+            collisionEnabled = serializedObject.FindProperty("collisionEnabled");
         }
 
         void OnSceneGUI() {
@@ -156,6 +162,9 @@ namespace SplineMesh {
                 }
             }
             EditorGUI.indentLevel -= 1;
+            EditorGUILayout.PropertyField(layer, true);
+            EditorGUILayout.PropertyField(visible, true);
+            EditorGUILayout.PropertyField(collisionEnabled, true);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/SplineMesh/Scripts/MeshProcessing/SplineExtrusion.cs
+++ b/Assets/SplineMesh/Scripts/MeshProcessing/SplineExtrusion.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,6 +32,9 @@ namespace SplineMesh {
         public Material material;
         public float textureScale = 1;
         public float sampleSpacing = 0.1f;
+        public string layer;
+        public bool visible = true;
+        public bool collisionEnabled = true;
 
         /// <summary>
         /// Clear shape vertices, then create three vertices with three normals for the extrusion to be visible
@@ -65,7 +68,7 @@ namespace SplineMesh {
             }
         }
 
-        private void GenerateMesh() {
+        protected void GenerateMesh() {
             UOUtility.DestroyChildren(generated);
 
             int i = 0;
@@ -77,13 +80,22 @@ namespace SplineMesh {
                     typeof(MeshRenderer),
                     typeof(ExtrusionSegment),
                     typeof(MeshCollider));
-                go.GetComponent<MeshRenderer>().material = material;
+                MeshRenderer goRenderer = go.GetComponent<MeshRenderer>();
+                goRenderer.material = material;
                 ExtrusionSegment seg = go.GetComponent<ExtrusionSegment>();
                 seg.ShapeVertices = shapeVertices;
                 seg.TextureScale = textureScale;
                 seg.TextureOffset = textureOffset;
                 seg.SampleSpacing = sampleSpacing;
                 seg.SetInterval(curve);
+                goRenderer.enabled = visible;
+                if (go.TryGetComponent(out MeshCollider meshCollider)) {
+                    meshCollider.enabled = collisionEnabled;
+                }
+                int layerNum = LayerMask.NameToLayer(layer);
+                if (layerNum > -1) {
+                    go.gameObject.layer = layerNum;
+                }
 
                 textureOffset += curve.Length;
             }


### PR DESCRIPTION
Just a few changes I found handy when using SplineMesh in a personal project. Figured they might be useful for other people too.

- Added extrusion layer/visibility/collision properties since I wanted some collision-only and visible-with-no-collision splines.
- Exposed spline index so my game logic could know if one spline came before/after another one.